### PR TITLE
Refactor database connection logic

### DIFF
--- a/app.js
+++ b/app.js
@@ -52,7 +52,7 @@ let timeOut, maxFileSize, maxJSONSize, allowedFileTypes;
 		maxJSONSize = envVariables.MAX_JSON_SIZE;
 		logger.info(`Data service max JSON size :: ${maxJSONSize}`);
 
-		let maxFileSize = envVariables.MAX_FILE_SIZE || "5MB";
+		maxFileSize = envVariables.MAX_FILE_SIZE || "5MB";
 		logger.info(`Data service max file upload size :: ${maxFileSize}`);
 
 		// FILE UPLOAD CONFIGURATIONS


### PR DESCRIPTION
In the try block returning `envVariables`, causes the subsequent code (the native MongoDB driver connections) not to be executed.
To address this, restructured the code to ensure that all the database connections are established before returning `envVariables`.